### PR TITLE
remove nullptr return for association collection conversion

### DIFF
--- a/k4LCIOReader/src/k4LCIOConverter.cc
+++ b/k4LCIOReader/src/k4LCIOConverter.cc
@@ -811,10 +811,6 @@ podio::CollectionBase *k4LCIOConverter::cnvReconstructedParticleCollection(EVENT
 
 podio::CollectionBase *k4LCIOConverter::cnvAssociationCollection(EVENT::LCCollection *src)
 {
-    unsigned nTotal = src->getNumberOfElements();
-    if (nTotal == 0) {
-        return nullptr;
-    }
 
     podio::CollectionBase* result = nullptr;
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove `nullptr` return on `cnvAssociationCollection()` when there are no elements.
- If no collections are found, it will return an empty `edm4hep::<something>AssociationCollection`. 

ENDRELEASENOTES

This is needed for consistency when using `k4LCIOConverter::getCollection(const std::string &name)` from outside `k4LCIOConverter` directly, as it will return a `nullptr` whereas the other converter functions will return an empty collection by default.