### PR TITLE
Test Fixes and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: linux
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SETUP: ['/cvmfs/sw.hsf.org/key4hep/setup.sh', '/cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh']
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - name: Start container
+      run: |
+        docker run -it --name CI_container -v ${GITHUB_WORKSPACE}:/Package -v /cvmfs:/cvmfs:shared -d clicdp/cc7-lcg /bin/bash
+    - name: Setup container
+      run: |
+        docker exec CI_container /bin/bash -c " ln -s /usr/lib64/liblzma.so.5.2.2 /usr/lib64/liblzma.so;"
+    - name: CMake Configure
+      run: |
+        docker exec CI_container /bin/bash -c 'cd Package;\
+         mkdir -p build install;\
+         source ${{ matrix.SETUP }};\
+         cd build;\
+         cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17  -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -G Ninja ..;'
+    - name: Compile 
+      run: |
+        docker exec CI_container /bin/bash -c 'cd ./Package;\
+        source ${{ matrix.SETUP }};\
+        cd build;\
+        ninja -k0;'
+    - name: Install
+      run: |
+        docker exec CI_container /bin/bash -c 'cd ./Package;\
+          source ${{ matrix.SETUP }};\
+          cd build;\
+          ninja -k0 install;'
+    - name: Test
+      run: |
+        docker exec CI_container /bin/bash -c 'cd ./Package;\
+        source ${{ matrix.SETUP }};\
+        cd build;\
+        ninja -k0 && ctest --output-on-failure;'
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.8)
 project(k4LCIOReader)
 
 option(BUILD_LCIOINPUT_IN_GAUDI "whether build the LCIOInput algorithm wrapper in Gaudi" ON)
-option(BUILD_TESTING "whether build the test(s)" OFF)
 
 find_package(ROOT COMPONENTS RIO Tree)
 
@@ -25,6 +24,8 @@ set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
 if(NOT CMAKE_CXX_STANDARD MATCHES "14|17")
   message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
 endif()
+
+include (CTest)
 
 add_subdirectory(k4LCIOReader)
 add_subdirectory(LCIOInput)

--- a/k4LCIOReader/CMakeLists.txt
+++ b/k4LCIOReader/CMakeLists.txt
@@ -15,11 +15,11 @@ target_include_directories(k4LCIOReader PUBLIC
 
 # - test
 if(BUILD_TESTING)
-    add_executable(read_lcio test/read_lcio.cc)
-    target_include_directories(read_lcio PUBLIC
+    add_executable(k4lcioreader_read-lcio test/read-lcio.cc)
+    target_include_directories(k4lcioreader_read-lcio PUBLIC
         ${podio_INCLUDE_DIR})
-    target_link_libraries(read_lcio k4LCIOReader)
-    add_test(NAME read_lcio COMMAND read_lcio)
+    target_link_libraries(k4lcioreader_read-lcio k4LCIOReader)
+    add_test(NAME read-lcio COMMAND wget https://key4hep.web.cern.ch/key4hep/testFiles/ddsimOutput/testSimulation.slcio; k4lcioreader_read-lcio testSimulation.slcio)
 endif()
 
 install(TARGETS k4LCIOReader

--- a/k4LCIOReader/test/read-lcio.cc
+++ b/k4LCIOReader/test/read-lcio.cc
@@ -7,10 +7,20 @@
 #include "edm4hep/MCRecoParticleAssociationCollection.h"
 #include "podio/EventStore.h"
 
-int main()
+int main(int argc, char *argv[])
 {
+    // simple command line parsing: get filename from first argument
+    std::string filename;
+    if (argc < 2) {
+      filename = "lciodata.slcio";
+      std::cout << "No filename given, defaulting to reading lciodata.slcio..." << std::endl;
+    } else {
+      filename = argv[1];
+      std::cout << "Reading file " << filename << "..." << std::endl;
+    }
+
     auto reader = k4LCIOReader();
-    reader.openFile( "lciodata.slcio" );
+    reader.openFile( filename );
 
     auto store = podio::EventStore();
     store.setReader(&reader);


### PR DESCRIPTION
BEGINRELEASENOTES
- BUILD_TESTING is a CTest builtin, no need to declare it as an option
- use test file from key4hep www space
- rename read_lcio exe to k4lcioreader_read-lcio - better in case it will be installed in the future
- simple cli for the read-lcio test (filename)

ENDRELEASENOTES
