### PR TITLE
tests: fix wget command

### DIFF
--- a/k4LCIOReader/CMakeLists.txt
+++ b/k4LCIOReader/CMakeLists.txt
@@ -19,7 +19,7 @@ if(BUILD_TESTING)
     target_include_directories(k4lcioreader_read-lcio PUBLIC
         ${podio_INCLUDE_DIR})
     target_link_libraries(k4lcioreader_read-lcio k4LCIOReader)
-    add_test(NAME prepare-input-files COMMAND wget https://key4hep.web.cern.ch/key4hep/testFiles/ddsimOutput/testSimulation.slcio)
+    add_test(NAME prepare-input-files COMMAND wget -N https://key4hep.web.cern.ch/key4hep/testFiles/ddsimOutput/testSimulation.slcio)
     set_tests_properties(prepare-input-files PROPERTIES FIXTURES_SETUP external_test_files)
     add_test(NAME read-lcio COMMAND k4lcioreader_read-lcio testSimulation.slcio)
     set_tests_properties(read-lcio PROPERTIES FIXTURES_REQUIRED external_test_files)

--- a/k4LCIOReader/CMakeLists.txt
+++ b/k4LCIOReader/CMakeLists.txt
@@ -19,7 +19,9 @@ if(BUILD_TESTING)
     target_include_directories(k4lcioreader_read-lcio PUBLIC
         ${podio_INCLUDE_DIR})
     target_link_libraries(k4lcioreader_read-lcio k4LCIOReader)
-    add_test(NAME read-lcio COMMAND wget https://key4hep.web.cern.ch/key4hep/testFiles/ddsimOutput/testSimulation.slcio; k4lcioreader_read-lcio testSimulation.slcio)
+    add_test(NAME prepare-input-files COMMAND wget https://key4hep.web.cern.ch/key4hep/testFiles/ddsimOutput/testSimulation.slcio)
+    add_test(NAME read-lcio COMMAND k4lcioreader_read-lcio testSimulation.slcio)
+    set_tests_properties(read-lcio PROPERTIES DEPENDS prepare-input-files)
 endif()
 
 install(TARGETS k4LCIOReader

--- a/k4LCIOReader/CMakeLists.txt
+++ b/k4LCIOReader/CMakeLists.txt
@@ -20,8 +20,9 @@ if(BUILD_TESTING)
         ${podio_INCLUDE_DIR})
     target_link_libraries(k4lcioreader_read-lcio k4LCIOReader)
     add_test(NAME prepare-input-files COMMAND wget https://key4hep.web.cern.ch/key4hep/testFiles/ddsimOutput/testSimulation.slcio)
+    set_tests_properties(prepare-input-files PROPERTIES FIXTURES_SETUP external_test_files)
     add_test(NAME read-lcio COMMAND k4lcioreader_read-lcio testSimulation.slcio)
-    set_tests_properties(read-lcio PROPERTIES DEPENDS prepare-input-files)
+    set_tests_properties(read-lcio PROPERTIES FIXTURES_REQUIRED external_test_files)
 endif()
 
 install(TARGETS k4LCIOReader


### PR DESCRIPTION
Split the test COMMAND to avoid CMake turning it  into something like this:
```
: Test command: /bin/wget "https://key4hep.web.cern.ch/key4hep/testFiles/ddsimOutput/testSimulation.slcio" ";" "k4lcioreader_read-lcio" "testSimulation.slcio"
```

BEGINRELEASENOTES
- tests: fix wget command

ENDRELEASENOTES
