### PR TITLE
Make k4LCIOReader conform to podio::IReader interface

### DIFF
--- a/k4LCIOReader/include/k4LCIOReader/k4LCIOReader.h
+++ b/k4LCIOReader/include/k4LCIOReader/k4LCIOReader.h
@@ -43,7 +43,7 @@ public:
     T *getCollection(const std::string &name);
 
     /// Read CollectionIDTable from ROOT file
-    podio::CollectionIDTable *getCollectionIDTable() override final { return m_table; }
+    std::shared_ptr<podio::CollectionIDTable> getCollectionIDTable() override final { return m_table; }
 
     /// Returns number of entries in the file
     unsigned getEntries() const { return m_entries; }
@@ -51,8 +51,11 @@ public:
     /// Preparing to read next event
     //void endOfEvent();
 
-    /// Preparing to read a given event
-    //void goToEvent(unsigned evnum);
+    /// Preparing to read a given event (not implemented, prescribed by interface)
+    void goToEvent(unsigned evnum) override {}
+
+    /// Read the event (not implemented, prescribed by interface)
+    void readEvent() override {}
 
     /// Check if TFile is valid
     virtual bool isValid() const override final;
@@ -79,7 +82,7 @@ private:
     k4LCIOConverter *m_converter;
 
     ///...
-    podio::CollectionIDTable *m_table;
+    std::shared_ptr<podio::CollectionIDTable> m_table;
 
     podio::version::Version m_fileVersion{0, 0, 0};
 };

--- a/k4LCIOReader/src/k4LCIOReader.cc
+++ b/k4LCIOReader/src/k4LCIOReader.cc
@@ -12,8 +12,8 @@ k4LCIOReader::k4LCIOReader()
     : m_entries(0),
       m_reader(nullptr)
 {
-    m_table = new podio::CollectionIDTable();
-    m_converter = new k4LCIOConverter(m_table);
+    m_table = std::make_shared<podio::CollectionIDTable>();
+    m_converter = new k4LCIOConverter(m_table.get());
 }
 
 k4LCIOReader::~k4LCIOReader()


### PR DESCRIPTION
BEGINRELEASENOTES
- Make the `k4LCIOReader` interface conform to `podio::IReader` again, after [AIDASoft/podio#323](https://github.com/AIDASoft/podio/pull/323)
  - The newly added functions are just stubs for the moment.

ENDRELEASENOTES

- [x] Needs AIDASoft/podio#323