### PR TITLE
Fix a memory leak in LCIO -> EDM4hep conversion

### DIFF
--- a/k4LCIOReader/include/k4LCIOReader/k4LCIOConverter.h
+++ b/k4LCIOReader/include/k4LCIOReader/k4LCIOConverter.h
@@ -18,7 +18,7 @@ public:
 
     void set(EVENT::LCEvent *evt);
 
-    podio::CollectionBase *getCollection(const std::string &name);
+    podio::CollectionBase *getCollection(const std::string &name, bool add_to_map=true);
 
 private:
     // convertion functions


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix a memory leak due to collections not being deleted

ENDRELEASENOTES

Fixes https://github.com/key4hep/k4MarlinWrapper/issues/96. The issue is that there are some collections that are created but never deleted so the fix is to make sure to delete them. When running with a file with events with tracks and clusters I don't get any memory leaks with this fix (and I do get them without the fix). To reproduce, build `k4LCIOReader` and then build `k4MarlinWrapper` (needed because the signature of one function changed).

Edit: After some discussion in the key4hep call, it has been pointed out that these collections may not be registered correctly