### PR TITLE
Delay cleanup

### DIFF
--- a/k4LCIOReader/include/k4LCIOReader/k4LCIOConverter.h
+++ b/k4LCIOReader/include/k4LCIOReader/k4LCIOConverter.h
@@ -54,6 +54,9 @@ private:
     std::map<std::string, EVENT::LCCollection *> m_name2src;
     std::map<std::string, podio::CollectionBase *> m_name2dest;
 
+    //Collection Name to Collection, for collections that are maybe not needed
+    std::map<std::string, podio::CollectionBase *> m_name2dest_tmp;
+
     typedef std::pair<EVENT::LCCollection *, podio::CollectionBase *> CollectionPair;
     // key: collection type, value: corresponding collection pairs
     std::map<std::string, std::vector<CollectionPair>> m_type2cols;

--- a/k4LCIOReader/include/k4LCIOReader/k4LCIOConverter.h
+++ b/k4LCIOReader/include/k4LCIOReader/k4LCIOConverter.h
@@ -55,7 +55,7 @@ private:
     std::map<std::string, podio::CollectionBase *> m_name2dest;
 
     //Collection Name to Collection, for collections that are maybe not needed
-    std::map<std::string, podio::CollectionBase *> m_name2dest_tmp;
+    std::map<std::string, std::unique_ptr<podio::CollectionBase>> m_name2dest_tmp;
 
     typedef std::pair<EVENT::LCCollection *, podio::CollectionBase *> CollectionPair;
     // key: collection type, value: corresponding collection pairs

--- a/k4LCIOReader/src/k4LCIOConverter.cc
+++ b/k4LCIOReader/src/k4LCIOConverter.cc
@@ -63,6 +63,7 @@ k4LCIOConverter::k4LCIOConverter(podio::CollectionIDTable *table)
 
 k4LCIOConverter::~k4LCIOConverter()
 {
+    set(nullptr);
 }
 
 void k4LCIOConverter::set(EVENT::LCEvent *evt)
@@ -75,6 +76,10 @@ void k4LCIOConverter::set(EVENT::LCEvent *evt)
         delete pair.second;
     }
     m_name2dest_tmp.clear();
+
+    if(not evt){
+      return;
+    }
 
     m_evt = evt;
     for (const auto &colname : *(evt->getCollectionNames()))
@@ -93,13 +98,18 @@ podio::CollectionBase *k4LCIOConverter::getCollection(const std::string &name, b
         return idest->second;
     }
     idest = m_name2dest_tmp.find(name);
-    if (idest != m_name2dest_tmp.end())
+    if (idest != m_name2dest_tmp.end() && add_to_map)
     {
         const auto name = idest->first;
         auto* dest = idest->second;
         m_name2dest[name] = dest;
         m_name2dest_tmp.erase(idest);
         return m_name2dest[name];
+    }
+    else if (idest != m_name2dest_tmp.end() && not add_to_map)
+    {
+        const auto name = idest->first;
+        return idest->second;
     }
 
     // in case of EventHeader

--- a/k4LCIOReader/src/k4LCIOConverter.cc
+++ b/k4LCIOReader/src/k4LCIOConverter.cc
@@ -71,6 +71,11 @@ void k4LCIOConverter::set(EVENT::LCEvent *evt)
     m_name2dest.clear();
     m_type2cols.clear();
 
+    for (auto pair: m_name2dest_tmp) {
+        delete pair.second;
+    }
+    m_name2dest_tmp.clear();
+
     m_evt = evt;
     for (const auto &colname : *(evt->getCollectionNames()))
     {
@@ -86,6 +91,15 @@ podio::CollectionBase *k4LCIOConverter::getCollection(const std::string &name, b
     if (idest != m_name2dest.end())
     {
         return idest->second;
+    }
+    idest = m_name2dest_tmp.find(name);
+    if (idest != m_name2dest_tmp.end())
+    {
+        const auto name = idest->first;
+        auto* dest = idest->second;
+        m_name2dest[name] = dest;
+        m_name2dest_tmp.erase(idest);
+        return m_name2dest[name];
     }
 
     // in case of EventHeader
@@ -125,11 +139,11 @@ podio::CollectionBase *k4LCIOConverter::getCollection(const std::string &name, b
       if (add_to_map) {
         // put result in data holders
         m_name2dest[name] = dest;
-
         m_type2cols[src->getTypeName()].push_back(std::make_pair(src, dest));
       }
       else {
-        delete dest;
+        m_name2dest_tmp[name] = dest;
+        m_type2cols[src->getTypeName()].push_back(std::make_pair(src, dest));
       }
     } catch (std::runtime_error& re) {
       std::cout << re.what() << std::endl;


### PR DESCRIPTION

BEGINRELEASENOTES
- k4LCIOConverter: only delete referenced collections if they are not later converted, fixes edm_converter test in k4MarlinWrapper (https://github.com/key4hep/k4MarlinWrapper/pull/112)

ENDRELEASENOTES

Did the previous implementation of `getCollection` just delete the collection when `add_to_map` was false, effectively doing nothing, or am I missing something?
